### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/JLCodeSource/log_aggregator/security/code-scanning/1](https://github.com/JLCodeSource/log_aggregator/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow file. Since the workflow only checks out the repository and builds a Docker image, it does not require write permissions. The `contents: read` permission is sufficient for these operations. This change will limit the permissions of the `GITHUB_TOKEN` to read-only access to the repository contents, reducing the risk of unintended write operations.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs in the workflow. This ensures consistency and avoids the need to repeat the permissions block for each job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
